### PR TITLE
Feat: 나의 독서 기록 조회 API 클라이언트

### DIFF
--- a/fairytale/src/api/records.ts
+++ b/fairytale/src/api/records.ts
@@ -1,0 +1,24 @@
+import axios from 'axios'
+
+// 환경변수 기반 엔드포인트 호스팅 주소 반영
+const API_BASE = process.env.REACT_APP_API_BASE
+
+export async function checkRecord(uid: number, fid: number) {
+  // JWT 토큰 확인
+  const token = localStorage.getItem('token')
+  const tokenType = localStorage.getItem('token_type') || 'bearer'
+
+  try {
+    // 로그인된 경우에만 나의 독서 기록 조회 가능
+    const res = await axios.get(`${API_BASE}/users/${uid}/check_records`, {
+      params: {fid},
+      headers: {
+        Authorization: `${tokenType} ${token}`
+      }
+    })
+    return res.data
+  } catch (error: any) {
+    console.error('checkRecord API 실패:', error.response?.data || error.message)
+    throw error
+  }
+}


### PR DESCRIPTION
## 작업 내용

- checkRecord 함수 구현
- 백엔드 독서 기록 조회 API(/users/{uid}/check_records) 연동
- uid(사용자 ID), fid(동화책 ID)를 기반으로 특정 사용자의 독서 기록 조회 가능
- 환경변수 기반 API 주소(REACT_APP_API_BASE) 적용 → 개발/운영 환경 분리 대응
- localStorage에서 token, token_type 가져와 Authorization 헤더에 반영

## PR POINT

- 환경변수 활용으로 유동적인 ngrok/배포 환경에서도 대응 가능
- 보안 강화: Authorization 헤더에 JWT 토큰을 포함하여 보호된 API 호출