### PR TITLE
Feat: 회원정보 수정 API 연동 클라이언트

### DIFF
--- a/fairytale/src/api/user_update.ts
+++ b/fairytale/src/api/user_update.ts
@@ -1,0 +1,27 @@
+import axios from 'axios'
+
+const API_BASE = process.env.REACT_APP_API_BASE
+
+// 회원정보 수정 API 연동
+export async function updateUser(payload: {
+  id: string
+  passwd: string
+  repasswd: string
+  name: string
+  address: string
+}) {
+  const token = localStorage.getItem('token')
+  const tokenType = localStorage.getItem('token_type')
+
+  try {
+    const res = await axios.post(`${API_BASE}/update_user`, payload, {
+      headers: {
+        Authorization: `${tokenType} ${token}`
+      }
+    })
+    return res.data
+  } catch (error: any) {
+    console.error('updateUser API 실패:', error.response?.data || error.message)
+    throw error
+  }
+}


### PR DESCRIPTION
## 작업 내용
- updateUser 함수 구현
- 회원정보 수정 API(/update_user) 연동
- id, passwd, repasswd, name, address 정보를 payload로 받아 백엔드에 전달
- 환경변수 기반 API 주소(REACT_APP_API_BASE) 적용
- JWT 인증 처리
- localStorage에서 token, token_type을 가져와 Authorization 헤더에 포함
- 요청 실패 시 콘솔 로그로 상세 정보 출력 후 예외 발생

## PR POINT

- 회원정보 수정 기능을 프론트엔드에서 직접 호출 가능하도록 API 연동 완료
- 환경변수 활용으로 ngrok/배포 환경 모두 대응 가능
- JWT 기반 Authorization 헤더 추가로 보안 강화
- 에러 로깅 및 예외 처리로 디버깅 및 유지보수 용이성 향상