### PR TITLE
Feat: 동화책 상세정보 조회 API 연동 클라이언트

### DIFF
--- a/fairytale/src/api/detail.ts
+++ b/fairytale/src/api/detail.ts
@@ -1,0 +1,23 @@
+import axios from 'axios'
+
+const API_BASE = process.env.REACT_APP_API_BASE
+
+// 동화책 상세정보 조회
+export async function getFairyTaleDetail(uid: number, fid: number) {
+  const token = localStorage.getItem('token')
+  const tokenType = localStorage.getItem('token_type') || 'bearer'
+
+  try {
+    // 로그인된 경우에만 동화책 상세 조회 가능
+    const res = await axios.get(`${API_BASE}/users/${uid}/detail`, {
+      params: {fid},
+      headers: {
+        Authorization: `${tokenType} ${token}`
+      }
+    })
+    return res.data
+  } catch (error: any) {
+    console.error('getFairyTaleDetail API 실패:', error.response?.data || error.message)
+    throw error
+  }
+}


### PR DESCRIPTION
## 작업 내용

- 프론트엔드에서 백엔드 동화책 상세조회 API(/users/{uid}/detail)를 호출할 수 있도록 axios 기반 함수 구현
- 로컬스토리지에 저장된 JWT 토큰을 헤더에 포함해 인증 처리

## PR POINT

- JWT 토큰을 헤더에 담아 인증 처리
- API 실패 시 상세한 에러 메시지 출력 및 예외 처리