### PR TITLE
Feat: 캐싱 기능 추가(IndexDB 기반)

### DIFF
--- a/fairytale/src/components/FairyTaleCard.tsx
+++ b/fairytale/src/components/FairyTaleCard.tsx
@@ -22,9 +22,11 @@ const FairyTaleCard: React.FC<FairyTaleCardProps> = ({
       className={`flex flex-col items-center p-4 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow cursor-pointer ${className}`}>
       <img src={imageSrc} alt={title} className="object-cover w-full rounded-md" />
       <div className="w-full mt-2 text-center">
-        <p className="text-sm font-semibold text-gray-800 truncate">{title}</p>
+        <p className="text-sm font-semibold text-gray-800 truncate font-pinkfong">
+          {title}
+        </p>
         <p className="mt-1 text-xs text-gray-500">{date}</p>
-        <p className="text-xs text-gray-500">{subText}</p>
+        <p className="text-xs text-gray-500 font-pinkfong">{subText}</p>
       </div>
     </div>
   )

--- a/fairytale/src/components/FairyTaleCarousel.tsx
+++ b/fairytale/src/components/FairyTaleCarousel.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react'
+// src/components/FairyTaleCarousel.tsx
+import React, {useState, useEffect} from 'react'
 import FairyTaleCard from './FairyTaleCard'
-import { Link } from 'react-router-dom'
-import { fetchDefaultFairyTales, FairyTale } from '../api/books'
+import {Link} from 'react-router-dom'
+import {fetchDefaultFairyTales, FairyTale} from '../api/books'
+import {getFairyTaleList, saveFairyTaleList} from '../utils/storyCache'
 
 const FairyTaleCarousel = () => {
   const [initialFairyTales, setInitialFairyTales] = useState<FairyTale[]>([])
@@ -10,12 +12,21 @@ const FairyTaleCarousel = () => {
   const [isTransitioning, setIsTransitioning] = useState(true)
   const [loading, setLoading] = useState(true)
 
-  // API에서 동화 가져오기
   useEffect(() => {
     const getFairyTales = async () => {
       try {
+        const cachedList = await getFairyTaleList()
+
+        if (cachedList) {
+          setInitialFairyTales(cachedList)
+          setLoading(false)
+          return
+        }
+
         const dbTales = await fetchDefaultFairyTales()
         setInitialFairyTales(dbTales)
+
+        await saveFairyTaleList(dbTales)
       } catch (error) {
         console.error('Failed to load fairy tales from API', error)
         setInitialFairyTales([])
@@ -26,24 +37,20 @@ const FairyTaleCarousel = () => {
     getFairyTales()
   }, [])
 
-  // 데이터 준비
   useEffect(() => {
     if (initialFairyTales.length > 0) {
       if (initialFairyTales.length >= 4) {
-        // 무한 캐러셀 구현용 앞뒤 클론
         const clonedBefore = initialFairyTales.slice(-4)
         const clonedAfter = initialFairyTales.slice(0, 4)
         setItems([...clonedBefore, ...initialFairyTales, ...clonedAfter])
-        setOffset(4) // 시작 위치
+        setOffset(4)
       } else {
-        // 데이터가 4개 미만이면 복제 없이 그대로 사용
         setItems(initialFairyTales)
         setOffset(0)
       }
     }
   }, [initialFairyTales])
 
-  // 자동 슬라이드
   useEffect(() => {
     if (items.length > 0 && initialFairyTales.length >= 4) {
       const interval = setInterval(() => {
@@ -53,7 +60,6 @@ const FairyTaleCarousel = () => {
     }
   }, [items, initialFairyTales])
 
-  // 끝까지 가면 리셋 (무한 루프 효과)
   useEffect(() => {
     if (initialFairyTales.length >= 4 && items.length > 0) {
       if (offset >= items.length - 4) {
@@ -68,16 +74,15 @@ const FairyTaleCarousel = () => {
   }, [offset, items, initialFairyTales])
 
   if (loading) {
-    return <div>로딩 중...</div>
+    return <div className="font-pinkfong text-center py-10">로딩 중...</div>
   }
 
   if (initialFairyTales.length === 0) {
-    return null // 데이터가 없으면 캐러셀 안 보여줌
+    return null
   }
 
   return (
-    <section className="p-6 mt-10 overflow-hidden bg-white border border-gray-200 shadow-xl rounded-2xl">
-      <h3 className="mb-6 text-xl font-bold text-gray-800">동화 리스트</h3>
+    <section className="p-6 mt-10 overflow-hidden bg-white border border-gray-200 shadow-xl rounded-2xl font-pinkfong">
       <div
         className={`flex ${
           isTransitioning && initialFairyTales.length >= 4
@@ -88,9 +93,8 @@ const FairyTaleCarousel = () => {
           transform:
             initialFairyTales.length >= 4
               ? `translateX(-${offset * 25}%)`
-              : 'translateX(0)',
-        }}
-      >
+              : 'translateX(0)'
+        }}>
         {items.map((tale, index) => (
           <div key={index} className="flex-shrink-0 w-1/4 px-2">
             <Link to={`/detail/${tale.fid}`}>

--- a/fairytale/src/components/FairyTaleList.tsx
+++ b/fairytale/src/components/FairyTaleList.tsx
@@ -3,6 +3,7 @@ import React, {useState, useEffect} from 'react'
 import FairyTaleCard from './FairyTaleCard'
 import {Link} from 'react-router-dom'
 import {check_records, FairyTale} from '../api/records'
+import {getReadingRecords, saveReadingRecords} from '../utils/storyCache'
 
 const FairyTaleList: React.FC = () => {
   const [fairyTales, setFairyTales] = useState<FairyTale[]>([])
@@ -13,10 +14,22 @@ const FairyTaleList: React.FC = () => {
     const fetchFairyTales = async () => {
       try {
         setIsLoading(true)
-        const data = await check_records(localStorage.uid)
+        const uid = localStorage.uid
+
+        const cachedRecords = await getReadingRecords(uid)
+
+        if (cachedRecords) {
+          setFairyTales(cachedRecords)
+          setIsLoading(false)
+          return
+        }
+
+        const data = await check_records(uid)
         setFairyTales(data.records)
+
+        await saveReadingRecords(uid, data.records)
       } catch (err) {
-        setError("읽은 기록이 없습니다.")
+        setError('읽은 기록이 없습니다.')
         console.error(err)
       } finally {
         setIsLoading(false)
@@ -29,9 +42,11 @@ const FairyTaleList: React.FC = () => {
   if (isLoading) {
     return (
       <section className="p-6 mt-10 bg-white border border-gray-200 shadow-xl rounded-2xl">
-        <h3 className="mb-6 text-xl font-bold text-gray-800">나의 동화 기록</h3>
+        <h3 className="mb-6 text-xl font-bold text-gray-800 font-pinkfong">
+          나의 독서 기록
+        </h3>
         <div className="flex items-center justify-center h-32">
-          <div className="text-gray-500">로딩 중...</div>
+          <div className="text-gray-500 font-pinkfong">로딩 중...</div>
         </div>
       </section>
     )
@@ -40,9 +55,11 @@ const FairyTaleList: React.FC = () => {
   if (error) {
     return (
       <section className="p-6 mt-10 bg-white border border-gray-200 shadow-xl rounded-2xl">
-        <h3 className="mb-6 text-xl font-bold text-gray-800">나의 동화 기록</h3>
+        <h3 className="mb-6 text-xl font-bold text-gray-800 font-pinkfong">
+          나의 독서 기록
+        </h3>
         <div className="flex justify-center items-center h-32">
-          <div className="text-gray-500">{error}</div>
+          <div className="text-gray-500 font-pinkfong">{error}</div>
         </div>
       </section>
     )
@@ -50,19 +67,21 @@ const FairyTaleList: React.FC = () => {
 
   return (
     <section className="p-6 mt-10 bg-white border border-gray-200 shadow-xl rounded-2xl">
-      <h3 className="mb-6 text-xl font-bold text-gray-800">나의 동화 기록</h3>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
-          {fairyTales.map(tale => (
-            <Link key={tale.fid} to={`/generate_story/${tale.fid}`} className="cursor-pointer">
-              <FairyTaleCard
-                imageSrc={tale.image_url}
-                title={tale.title}
-                date={tale.create_date}
-                subText={tale.summary}
-              />
-            </Link>
-          ))}
-        </div>
+      <h3 className="mb-6 text-xl font-bold text-gray-800 font-pinkfong">
+        나의 독서 기록
+      </h3>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
+        {fairyTales.map(tale => (
+          <Link key={tale.fid} to={`/detail/${tale.fid}`} className="cursor-pointer">
+            <FairyTaleCard
+              imageSrc={tale.image_url}
+              title={tale.title}
+              date={tale.create_date}
+              subText={tale.summary}
+            />
+          </Link>
+        ))}
+      </div>
     </section>
   )
 }

--- a/fairytale/src/pages/detail.tsx
+++ b/fairytale/src/pages/detail.tsx
@@ -3,8 +3,8 @@ import {useParams, useNavigate} from 'react-router-dom'
 import Header from '../components/Header'
 import Button from '../components/Button'
 import {getFairyTaleDetail} from '../api/detail'
+import {getFairyTaleDetailCache, saveFairyTaleDetail} from '../utils/storyCache'
 
-// API 응답 타입 정의
 interface FairyTaleDetail {
   uid: number
   type: string
@@ -12,35 +12,10 @@ interface FairyTaleDetail {
   summary: string
   contents: string
   create_dates: string
-  image_url: string | null // API 함수에서 clips를 image_url로 변환해서 반환
+  image_url: string | null
 }
 
-// JWT 파싱 유틸 (현재 사용하지 않지만 추후 사용 가능)
-// interface JWTPayload {
-//   sub?: string | number
-//   uid?: string | number
-//   exp?: number
-// }
-
-// function parseJwt(token: string): JWTPayload | null {
-//   try {
-//     const base64Url = token.split('.')[1]
-//     if (!base64Url) return null
-//     const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
-//     const jsonPayload = decodeURIComponent(
-//       atob(base64)
-//         .split('')
-//         .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
-//         .join('')
-//     )
-//     return JSON.parse(jsonPayload)
-//   } catch {
-//     return null
-//   }
-// }
-
 const StoryDetailPage: React.FC = () => {
-  // 라우팅이 /detail/:fid 이므로 fid로 직접 가져옵니다
   const {fid} = useParams<{fid: string}>()
   const navigate = useNavigate()
 
@@ -48,20 +23,14 @@ const StoryDetailPage: React.FC = () => {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  // 이미지 URL 조합 함수 (사용 안 함 - 삭제)
-  // const getImageUrl = (imagePath: string | null) => { ... }
-
   useEffect(() => {
     const fetchStoryDetail = async () => {
       try {
         console.log('🔍 디버깅 시작')
         console.log('📋 URL 파라미터 fid:', fid)
 
-        // JWT에서 uid 추출
         const token = localStorage.getItem('token')
         const uidStr = localStorage.getItem('uid')
-        console.log('🔑 토큰 존재 여부:', token ? '있음' : '없음')
-        console.log('👤 UID from localStorage:', uidStr)
 
         if (!token) {
           console.log('❌ 토큰이 없어서 로그인 페이지로 이동')
@@ -70,8 +39,6 @@ const StoryDetailPage: React.FC = () => {
         }
 
         const uid = uidStr ? Number(uidStr) : null
-        console.log('🔢 변환된 UID:', uid, 'FID:', fid)
-        console.log('🔢 UID 타입:', typeof uid, 'FID 타입:', typeof fid)
 
         if (!uid || !fid) {
           console.log('❌ 필요한 정보 누락 - UID:', uid, 'FID:', fid)
@@ -79,24 +46,29 @@ const StoryDetailPage: React.FC = () => {
           return
         }
 
+        // 1. 먼저 캐시 확인
+        const cachedDetail = await getFairyTaleDetailCache(Number(fid))
+
+        if (cachedDetail) {
+          // 캐시가 있으면 바로 표시
+          console.log('✅ 캐시에서 로드됨')
+          setStoryData(cachedDetail)
+          setLoading(false)
+          return
+        }
+
         console.log('🚀 API 호출 시작 - UID:', Number(uid), 'FID:', Number(fid))
 
-        // API 호출
+        // 2. 캐시가 없으면 API 호출
         const data = await getFairyTaleDetail(Number(uid), Number(fid))
         console.log('✅ API 응답 성공:', data)
-        console.log('📅 create_dates 값:', data.create_dates)
-        console.log('📅 create_dates 타입:', typeof data.create_dates)
-        console.log('🖼️ 원본 image_url:', data.image_url)
 
         setStoryData(data)
+
+        // 3. 새로 받은 데이터 캐시에 저장
+        await saveFairyTaleDetail(Number(fid), data)
       } catch (error: any) {
         console.error('❌ 동화 상세 정보 로딩 실패:', error)
-        console.error('📊 에러 상세 정보:', {
-          status: error.response?.status,
-          statusText: error.response?.statusText,
-          data: error.response?.data,
-          message: error.message
-        })
 
         if (error.response?.status === 404) {
           setError('해당 동화를 찾을 수 없습니다.')
@@ -116,7 +88,6 @@ const StoryDetailPage: React.FC = () => {
     fetchStoryDetail()
   }, [fid, navigate])
 
-  // 로딩 상태
   if (loading) {
     return (
       <div className="min-h-screen bg-pink-50">
@@ -125,18 +96,12 @@ const StoryDetailPage: React.FC = () => {
           <div className="flex items-center justify-center py-16">
             <div className="bg-white rounded-3xl shadow-lg max-w-2xl w-full p-8 md:p-12">
               <div className="flex flex-col items-center text-center space-y-8">
-                {/* 이미지 스켈레톤 */}
                 <div className="flex justify-center">
                   <div
                     className="bg-gray-200 rounded-2xl animate-pulse"
-                    style={{
-                      width: '280px',
-                      height: '350px'
-                    }}
+                    style={{width: '280px', height: '350px'}}
                   />
                 </div>
-
-                {/* 텍스트 스켈레톤 */}
                 <div className="space-y-6 w-full">
                   <div className="h-8 bg-gray-200 rounded animate-pulse mx-auto w-3/4" />
                   <div className="h-4 bg-gray-200 rounded animate-pulse mx-auto w-24" />
@@ -155,7 +120,6 @@ const StoryDetailPage: React.FC = () => {
     )
   }
 
-  // 에러 상태
   if (error) {
     return (
       <div className="min-h-screen bg-pink-50">
@@ -178,7 +142,6 @@ const StoryDetailPage: React.FC = () => {
     )
   }
 
-  // 데이터가 없는 경우
   if (!storyData) {
     return (
       <div className="min-h-screen bg-pink-50">
@@ -203,14 +166,12 @@ const StoryDetailPage: React.FC = () => {
     )
   }
 
-  // 날짜 포맷팅
   const formatDate = (dateString: string) => {
     if (!dateString) return '날짜 정보 없음'
 
     try {
       const date = new Date(dateString)
 
-      // Invalid Date 체크
       if (isNaN(date.getTime())) {
         console.warn('잘못된 날짜 형식:', dateString)
         return dateString
@@ -230,17 +191,14 @@ const StoryDetailPage: React.FC = () => {
     }
   }
 
-  // 정상 렌더링
   return (
     <div className="min-h-screen bg-pink-50">
       <Header />
 
-      {/* Main Content */}
       <div className="container mx-auto p-4">
         <div className="flex items-center justify-center py-16">
           <div className="bg-white rounded-3xl shadow-lg max-w-2xl w-full p-8 md:p-12">
             <div className="flex flex-col items-center text-center space-y-8">
-              {/* Book Cover */}
               <div className="flex justify-center">
                 <img
                   src={
@@ -255,7 +213,6 @@ const StoryDetailPage: React.FC = () => {
                     objectFit: 'cover'
                   }}
                   onError={e => {
-                    // 이미지 로드 실패 시 기본 이미지로 대체
                     const target = e.target as HTMLImageElement
                     target.src =
                       'https://images.unsplash.com/photo-1544947950-fa07a98d237f?auto=format&fit=crop&w=300&h=400'
@@ -263,24 +220,19 @@ const StoryDetailPage: React.FC = () => {
                 />
               </div>
 
-              {/* Story Details */}
               <div className="space-y-6">
-                {/* Title */}
                 <h1 className="text-3xl md:text-4xl font-bold text-gray-800 leading-tight font-pinkfong">
                   {storyData.title}
                 </h1>
 
-                {/* Date */}
                 <p className="text-base text-gray-600 font-medium">
                   {formatDate(storyData.create_dates)}
                 </p>
 
-                {/* Summary */}
                 <p className="text-lg text-gray-700 leading-relaxed whitespace-pre-line font-pinkfong max-w-lg mx-auto">
                   {storyData.summary}
                 </p>
 
-                {/* Action Button */}
                 <div className="pt-4">
                   <Button to={`/generate_story/${fid}`} className="text-lg px-8 py-3">
                     동화책 읽으러 가기 &gt;&gt;

--- a/fairytale/src/pages/generate_story.tsx
+++ b/fairytale/src/pages/generate_story.tsx
@@ -9,6 +9,13 @@ import {getAllImages} from '../api/image'
 import {generateStoryStream} from '../api/story_generate'
 import {updateReadingProgress} from '../api/progress'
 import PageFlip from '../components/PageFlip'
+import {
+  saveImage,
+  getImage,
+  saveFairyTaleMeta,
+  getFairyTaleMeta,
+  clearOldCache
+} from '../utils/storyCache'
 
 const PAGE_W = 530
 const PAGE_H = 680
@@ -58,7 +65,6 @@ const GenerateStory = () => {
 
   const [currentPage, setCurrentPage] = useState(0)
   const [initialPage, setInitialPage] = useState(0)
-  const [bookKey, setBookKey] = useState(0)
   const [isDataReady, setIsDataReady] = useState(false)
   const [isPlaying, setIsPlaying] = useState(false)
   const [playingPage, setPlayingPage] = useState<number | null>(null)
@@ -68,6 +74,12 @@ const GenerateStory = () => {
   const bookContainerRef = useRef<HTMLDivElement | null>(null)
   const pageFlipRef = useRef<any>(null)
   const progressUpdateTimer = useRef<NodeJS.Timeout | null>(null)
+  const currentPageRef = useRef<number>(0)
+
+  // 앱 시작 시 오래된 캐시 정리
+  useEffect(() => {
+    clearOldCache()
+  }, [])
 
   useEffect(() => {
     const token = localStorage.getItem('token')
@@ -98,28 +110,12 @@ const GenerateStory = () => {
 
   const isStreamMode = !fid
 
+  // 현재 페이지를 ref에 동기화
   useEffect(() => {
-    if (isStreamMode && uid) {
-      const urlParams = new URLSearchParams(window.location.search)
-      const name = urlParams.get('name') || ''
-      const age = parseInt(urlParams.get('age') || '7')
-      const genre = urlParams.get('genre') || ''
+    currentPageRef.current = currentPage
+  }, [currentPage])
 
-      if (name && age && genre) {
-        startStreamGeneration({name, age, genre, uid, type: 2})
-      } else {
-        setError('동화 생성에 필요한 정보가 없습니다. 다시 시도해주세요.')
-        setLoading(false)
-      }
-    }
-  }, [isStreamMode, uid])
-
-  useEffect(() => {
-    if (!isStreamMode && uid && fid) {
-      loadExistingFairyTale()
-    }
-  }, [isStreamMode, uid, fid])
-
+  // debounce된 진행 상황 저장 (페이지 전환 시 사용)
   const debouncedUpdateProgress = useCallback(
     (page: number) => {
       const currentFid = completedFid || fid
@@ -131,10 +127,11 @@ const GenerateStory = () => {
 
       progressUpdateTimer.current = setTimeout(async () => {
         try {
-          // Clip 번호 계산 (페이지 0-1 = Clip 1, 2-3 = Clip 2, 4-5 = Clip 3)
           const clipNumber = Math.floor(page / 2) + 1
           await updateReadingProgress(uid, parseInt(currentFid, 10), clipNumber)
-          console.log(`Clip ${clipNumber} (페이지 ${page}-${page + 1}) 진행 상황 저장됨`)
+          console.log(
+            `[Debounce] Clip ${clipNumber} (페이지 ${page}-${page + 1}) 진행 상황 저장됨`
+          )
         } catch (error) {
           console.error('진행 상황 저장 실패:', error)
         }
@@ -143,72 +140,147 @@ const GenerateStory = () => {
     [uid, fid, completedFid]
   )
 
-  const startStreamGeneration = async (storyData: any) => {
-    setIsGenerating(true)
-    setStreamingPages([])
-    setLoading(true)
-    setIsStreamCompleted(false)
+  // 페이지 이탈/탭 전환 시 즉시 저장
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        const currentFid = completedFid || fid
+        if (uid && currentFid && currentPageRef.current !== undefined) {
+          const clipNumber = Math.floor(currentPageRef.current / 2) + 1
 
-    try {
-      await generateStoryStream(storyData, pageData => {
-        if (pageData.page) {
-          const newPage: StreamingPage = {
-            text: pageData.content,
-            page: pageData.page
+          // sendBeacon을 사용하여 페이지 이탈 시에도 확실하게 전송
+          const apiUrl = `/api/users/${uid}/fairy_tales/${parseInt(
+            currentFid,
+            10
+          )}/progress`
+          const data = JSON.stringify({next_page: clipNumber})
+
+          if (navigator.sendBeacon) {
+            const blob = new Blob([data], {type: 'application/json'})
+            const success = navigator.sendBeacon(apiUrl, blob)
+            console.log(
+              `[visibilitychange] sendBeacon 전송 ${
+                success ? '성공' : '실패'
+              }: Clip ${clipNumber}`
+            )
+          } else {
+            // sendBeacon 미지원 브라우저 대비
+            updateReadingProgress(uid, parseInt(currentFid, 10), clipNumber).catch(err =>
+              console.error('진행 상황 저장 실패:', err)
+            )
           }
-
-          if (pageData.title && !streamTitle) {
-            setStreamTitle(pageData.title)
-          }
-
-          setStreamingPages(prev => [...prev, newPage])
-
-          if (pageData.image) {
-            setPageImages(prev => ({
-              ...prev,
-              [pageData.page - 1]: pageData.image
-            }))
-            setImageLoadStates(prev => ({
-              ...prev,
-              [pageData.page - 1]: true
-            }))
-          }
-
-          setCurrentPage(pageData.page - 1)
-          setLoading(false)
-        } else if (pageData.completed) {
-          setIsGenerating(false)
-          setIsStreamCompleted(true)
-          setCompletedFid(pageData.fid)
-          setLoading(false)
-
-          console.log('동화 생성 완료:', pageData.fid)
-
-          window.history.replaceState(
-            {
-              fromStreaming: true,
-              streamedPages: streamingPages,
-              streamedTitle: streamTitle,
-              streamedImages: pageImages
-            },
-            '',
-            `/generate_story/${pageData.fid}`
-          )
-        } else if (pageData.error) {
-          setIsGenerating(false)
-          setLoading(false)
-          setError(pageData.error)
         }
-      })
-    } catch (error) {
-      setIsGenerating(false)
-      setLoading(false)
-      setError('동화 생성에 실패했습니다.')
-      console.error('스트리밍 에러:', error)
+      }
     }
-  }
 
-  const loadExistingFairyTale = async () => {
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+
+      // debounce 타이머 정리
+      if (progressUpdateTimer.current) {
+        clearTimeout(progressUpdateTimer.current)
+      }
+
+      // 언마운트 시에도 저장 시도
+      const currentFid = completedFid || fid
+      if (uid && currentFid && currentPageRef.current !== undefined) {
+        const clipNumber = Math.floor(currentPageRef.current / 2) + 1
+        updateReadingProgress(uid, parseInt(currentFid, 10), clipNumber)
+          .then(() => {
+            console.log(
+              `[언마운트] Clip ${clipNumber} (페이지 ${currentPageRef.current}) 진행 상황 저장됨`
+            )
+          })
+          .catch(error => {
+            console.error('언마운트 시 진행 상황 저장 실패:', error)
+          })
+      }
+    }
+  }, [uid, fid, completedFid])
+
+  const startStreamGeneration = useCallback(
+    async (storyData: any) => {
+      setIsGenerating(true)
+      setStreamingPages([])
+      setLoading(true)
+      setIsStreamCompleted(false)
+
+      try {
+        await generateStoryStream(storyData, async pageData => {
+          if (pageData.page) {
+            const newPage: StreamingPage = {
+              text: pageData.content,
+              page: pageData.page
+            }
+
+            if (pageData.title && !streamTitle) {
+              setStreamTitle(pageData.title)
+            }
+
+            setStreamingPages(prev => [...prev, newPage])
+
+            if (pageData.image) {
+              setPageImages(prev => ({
+                ...prev,
+                [pageData.page - 1]: pageData.image
+              }))
+              setImageLoadStates(prev => ({
+                ...prev,
+                [pageData.page - 1]: true
+              }))
+            }
+
+            setCurrentPage(pageData.page - 1)
+            setLoading(false)
+          } else if (pageData.completed) {
+            setIsGenerating(false)
+            setIsStreamCompleted(true)
+            setCompletedFid(pageData.fid)
+            setLoading(false)
+
+            console.log('동화 생성 완료:', pageData.fid)
+
+            // 생성 완료 후 캐시 저장
+            if (pageData.fid && streamTitle && streamingPages.length > 0) {
+              await saveFairyTaleMeta(pageData.fid, streamTitle, streamingPages)
+
+              // 이미지도 캐시에 저장
+              const imageEntries = Object.entries(pageImages)
+              for (const [idx, imageData] of imageEntries) {
+                await saveImage(pageData.fid, parseInt(idx), imageData as string)
+              }
+              console.log('캐시 저장 완료')
+            }
+
+            window.history.replaceState(
+              {
+                fromStreaming: true,
+                streamedPages: streamingPages,
+                streamedTitle: streamTitle,
+                streamedImages: pageImages
+              },
+              '',
+              `/generate_story/${pageData.fid}`
+            )
+          } else if (pageData.error) {
+            setIsGenerating(false)
+            setLoading(false)
+            setError(pageData.error)
+          }
+        })
+      } catch (error) {
+        setIsGenerating(false)
+        setLoading(false)
+        setError('동화 생성에 실패했습니다.')
+        console.error('스트리밍 에러:', error)
+      }
+    },
+    [streamTitle, streamingPages, pageImages]
+  )
+
+  const loadExistingFairyTale = useCallback(async () => {
     const fidNum = fid ? parseInt(fid, 10) : NaN
 
     if (!uid || !fid || Number.isNaN(fidNum)) {
@@ -228,68 +300,110 @@ const GenerateStory = () => {
         setPageImages(navigationState.streamedImages || {})
         setIsStreamCompleted(true)
         setCompletedFid(fid)
-        setIsDataReady(true) // 스트리밍에서 돌아온 경우
+        setIsDataReady(true)
         setLoading(false)
         return
       }
 
+      // 1. 먼저 캐시에서 메타데이터 확인
+      const cachedMeta = await getFairyTaleMeta(fid)
+
+      // 2. 서버에서 동화책 데이터 가져오기
       const data = await getFairyTaleById(uid, fidNum)
       setFairyTale(data)
-      setIsDataReady(true) // 데이터 로드 완료
+      setIsDataReady(true)
 
-      const imageFolderPath = `/content/gdrive/MyDrive/Colab Notebooks/fairyTale_images/${data.title}`
+      // 3. 캐시된 이미지 먼저 로드
+      let hasAllCachedImages = true
+      const imageMap: {[key: number]: string} = {}
 
-      try {
-        const imagesData = await getAllImages(imageFolderPath)
-        if (imagesData && imagesData.images.length > 0) {
-          const imageMap: {[key: number]: string} = {}
-          imagesData.images.forEach((img: any, index: number) => {
-            imageMap[index] = `data:image/png;base64,${img.image}`
-            setImageLoadStates(prev => ({...prev, [index]: true}))
-          })
-          setPageImages(imageMap)
+      for (let i = 0; i < data.pages.length; i++) {
+        const cachedImage = await getImage(fid, i)
+        if (cachedImage) {
+          imageMap[i] = cachedImage
+          setImageLoadStates(prev => ({...prev, [i]: true}))
+        } else {
+          hasAllCachedImages = false
         }
-      } catch (error) {
-        console.error('이미지 로딩 실패:', error)
       }
 
+      if (Object.keys(imageMap).length > 0) {
+        setPageImages(imageMap)
+        console.log(`캐시에서 ${Object.keys(imageMap).length}개 이미지 로드됨`)
+      }
+
+      // 4. 캐시되지 않은 이미지가 있으면 서버에서 가져오기
+      if (!hasAllCachedImages) {
+        const imageFolderPath = `/content/gdrive/MyDrive/Colab Notebooks/fairyTale_images/${data.title}`
+
+        try {
+          const imagesData = await getAllImages(imageFolderPath)
+          if (imagesData && imagesData.images.length > 0) {
+            for (let index = 0; index < imagesData.images.length; index++) {
+              const img = imagesData.images[index]
+              const imageData = `data:image/png;base64,${img.image}`
+
+              if (!imageMap[index]) {
+                imageMap[index] = imageData
+                setImageLoadStates(prev => ({...prev, [index]: true}))
+                await saveImage(fid, index, imageData)
+              }
+            }
+            setPageImages(imageMap)
+            console.log('서버에서 추가 이미지 로드 및 캐시 저장 완료')
+          }
+        } catch (error) {
+          console.error('이미지 로딩 실패:', error)
+        }
+      }
+
+      // 5. 메타데이터가 캐시에 없으면 저장
+      if (!cachedMeta && data.title && data.pages) {
+        await saveFairyTaleMeta(fid, data.title, data.pages)
+      }
+
+      // 6. 이어읽기 처리
       try {
         const resumeData = await resumeReading(uid, fidNum)
-        // next_page는 clip 번호 (1, 2, 3...)
         const clipNumber = resumeData?.next_page ?? 1
-        // clip을 시작 페이지 인덱스로 변환 (Clip 1 → 페이지 0, Clip 2 → 페이지 2)
         const startIdx = (clipNumber - 1) * 2
 
         console.log(`이어읽기: clipNumber=${clipNumber}, startIdx=${startIdx}`)
 
-        // 먼저 로딩 완료
         setLoading(false)
-
-        // 페이지 상태 설정
         setCurrentPage(startIdx)
         setInitialPage(startIdx)
-
-        // DOM이 렌더링된 후 페이지 이동
-        // setTimeout(() => {
-        //   if (pageFlipRef.current && startIdx > 0) {
-        //     try {
-        //       console.log(`turnToPage(${startIdx}) 호출`)
-        //       pageFlipRef.current.pageFlip().turnToPage(startIdx)
-        //     } catch (err) {
-        //       console.error('페이지 이동 실패:', err)
-        //     }
-        //   }
-        // }, 1000)
       } catch (err) {
         console.error('이어읽기 실패:', err)
-        // 이어읽기 실패 시에도 로딩 완료
         setLoading(false)
       }
     } catch (err: any) {
       setError(err.message || '동화책을 불러오는데 실패했습니다.')
       setLoading(false)
     }
-  }
+  }, [uid, fid, navigate])
+
+  useEffect(() => {
+    if (isStreamMode && uid) {
+      const urlParams = new URLSearchParams(window.location.search)
+      const name = urlParams.get('name') || ''
+      const age = parseInt(urlParams.get('age') || '7')
+      const genre = urlParams.get('genre') || ''
+
+      if (name && age && genre) {
+        startStreamGeneration({name, age, genre, uid, type: 2})
+      } else {
+        setError('동화 생성에 필요한 정보가 없습니다. 다시 시도해주세요.')
+        setLoading(false)
+      }
+    }
+  }, [isStreamMode, uid, startStreamGeneration])
+
+  useEffect(() => {
+    if (!isStreamMode && uid && fid) {
+      loadExistingFairyTale()
+    }
+  }, [isStreamMode, uid, fid, loadExistingFairyTale])
 
   const handleImageError = (pageIndex: number) => {
     setImageLoadStates(prev => ({...prev, [pageIndex]: false}))
@@ -583,7 +697,6 @@ const GenerateStory = () => {
               title="왼쪽 클릭: 이전 / 오른쪽 클릭: 다음">
               {isDataReady && (
                 <PageFlip
-                  key={bookKey}
                   ref={pageFlipRef}
                   width={PAGE_W}
                   height={PAGE_H}


### PR DESCRIPTION
**작업 내용 정리**

### FairyTaleCard.tsx
- `title`에 **font-pinkfong** 폰트 적용  
- `subText`에 **font-pinkfong** 폰트 적용  

### FairyTaleCarousel.tsx
- IndexedDB 캐시 기능 추가 (`getFairyTaleList`, `saveFairyTaleList`)  
- 캐시된 데이터 우선 로드, 없으면 API 호출  
- API로 받아온 데이터를 캐시에 저장  
- 로딩 메시지에 **font-pinkfong** 폰트 적용  
- 섹션에 **font-pinkfong** 폰트 적용  
- 불필요한 주석 제거 및 코드 정리  

### FairyTaleList.tsx
- IndexedDB 캐시 기능 추가 (`getReadingRecords`, `saveReadingRecords`)  
- 캐시된 독서 기록 우선 로드, 없으면 API 호출  
- API로 받아온 데이터를 캐시에 저장  
- `"나의 동화 기록"` → `"나의 독서 기록"`으로 변경  
- 카드 링크: `/generate_story/${fid}` → `/detail/${fid}` 변경  
- 로딩 및 에러 메시지에 **font-pinkfong** 폰트 적용  

### detail.tsx
- IndexedDB 캐시 기능 추가 (`getFairyTaleDetailCache`, `saveFairyTaleDetail`)  
- 캐시된 상세 정보 우선 로드, 없으면 API 호출  
- API로 받아온 데이터를 캐시에 저장  
- 불필요한 주석 및 사용하지 않는 코드 제거  
- 디버깅 로그 정리  

### generate_story.tsx
- IndexedDB 캐시 시스템 전면 도입  
  - 동화 메타데이터 캐시 (`saveFairyTaleMeta`, `getFairyTaleMeta`)  
  - 이미지 캐시 (`saveImage`, `getImage`)  
  - 오래된 캐시 자동 정리 (`clearOldCache`)  

- **페이지 이탈 감지 및 진행 상황 즉시 저장**  
  - `visibilitychange` 이벤트로 탭 전환/페이지 이동 감지  
  - `navigator.sendBeacon` API로 안정적인 데이터 전송 보장  
  - 언마운트 시에도 현재 페이지 저장  

- **캐시 우선 로드 전략**  
  - 동화 메타데이터 및 이미지를 캐시에서 먼저 로드  
  - 캐시 미스 시 서버에서 가져와 캐시에 저장  

- **기타 개선 사항**  
  - 스트리밍 완료 후 캐시 저장  
  - `useCallback`으로 함수 메모이제이션  
  - `currentPageRef`로 최신 페이지 상태 추적  
  - 불필요한 `bookKey` state 제거  

---

**PR POINT**
- IndexedDB 기반 캐시 시스템 구현으로 네트워크 요청 최소화 및 로딩 속도 개선  
- 페이지 이탈 시 읽기 진행 상황 즉시 저장으로 데이터 손실 방지  
- `sendBeacon` API 활용으로 페이지 언로드 중에도 안정적인 데이터 전송 보장  
- 캐시 우선 로드 전략으로 사용자 경험 향상  
- 일관된 폰트 적용 및 불필요한 코드 정리로 코드 품질 개선  